### PR TITLE
Upgrade: Gradle to 8.13 and AGP to 8.11.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ sqldelight = "2.0.1"
 koin = "3.5.3"
 turbine = "1.0.0"
 mockk = "1.13.8"
-agp = "8.2.2"
+agp = "8.11.0"
 kover = "0.7.5"
 dokka = "1.9.10"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This commit updates the project's build tools:
- Gradle wrapper upgraded to version 8.13.
- Android Gradle Plugin (AGP) version updated to 8.11.0.